### PR TITLE
Add option to display more significant figures for position/velocity metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 *.sublime-project
 *.sublime-workspace
 .eslintcache
+package-lock.json

--- a/js/MySolarSystemStrings.ts
+++ b/js/MySolarSystemStrings.ts
@@ -32,6 +32,7 @@ type StringsType = {
     'positionStringProperty': LocalizedStringProperty;
     'bodiesStringProperty': LocalizedStringProperty;
     'moreDataStringProperty': LocalizedStringProperty;
+    'moreDecimalDigitsStringProperty': LocalizedStringProperty;
   };
   'massStringProperty': LocalizedStringProperty;
   'mode': {
@@ -72,6 +73,7 @@ type StringsType = {
   };
   'a11y': {
     'moreDataStringProperty': LocalizedStringProperty;
+    'moreDecimalDigitsStringProperty': LocalizedStringProperty;
     'infoStringProperty': LocalizedStringProperty;
     'numberOfBodiesStringProperty': LocalizedStringProperty;
     'introScreen': {

--- a/js/common/view/MySolarSystemCheckbox.ts
+++ b/js/common/view/MySolarSystemCheckbox.ts
@@ -78,6 +78,27 @@ export default class MySolarSystemCheckbox extends SolarSystemCommonCheckbox {
       tandem: tandem
     } );
   }
+
+  /**
+   * Creates the 'Show More Digits' checkbox
+   * This checkbox displays more digits for the position and velocity sections.
+   */
+  public static createMoreDigitsCheckbox(
+    moreDecimalDigitsProperty: Property<boolean>,
+    moreDataVisibleProperty: Property<boolean>,
+    tandem: Tandem
+  ): SolarSystemCommonCheckbox {
+    return new SolarSystemCommonCheckbox( moreDecimalDigitsProperty, MySolarSystemStrings.dataPanel.moreDecimalDigitsStringProperty, {
+      textOptions: {
+        maxWidth: 300
+      },
+      touchAreaXDilation: 10,
+      touchAreaYDilation: 10,
+      accessibleName: MySolarSystemStrings.a11y.moreDecimalDigitsStringProperty,
+      tandem: tandem,
+      visibleProperty: moreDataVisibleProperty
+    } );
+  }
 }
 
 mySolarSystem.register( 'MySolarSystemCheckbox', MySolarSystemCheckbox );

--- a/js/common/view/MySolarSystemScreenView.ts
+++ b/js/common/view/MySolarSystemScreenView.ts
@@ -158,10 +158,19 @@ export default class MySolarSystemScreenView extends SolarSystemCommonScreenView
 
     const valuesPanelTandem = this.panelsTandem.createTandem( 'valuesPanel' );
 
-    this.valuesPanel = new ValuesPanel( model, this.visibleProperties.moreDataVisibleProperty, valuesPanelTandem );
+    this.valuesPanel = new ValuesPanel(
+      model, this.visibleProperties.moreDataVisibleProperty,
+      this.visibleProperties.moreDigitsProperty, valuesPanelTandem
+    );
 
     const moreDataCheckbox = MySolarSystemCheckbox.createMoreDataCheckbox( this.visibleProperties.moreDataVisibleProperty,
       model.isLab ? valuesPanelTandem.createTandem( 'moreDataCheckbox' ) : Tandem.OPT_OUT );
+
+    const moreDigitsCheckbox = MySolarSystemCheckbox.createMoreDigitsCheckbox(
+      this.visibleProperties.moreDigitsProperty,
+      this.visibleProperties.moreDataVisibleProperty,
+      valuesPanelTandem.createTandem( 'moreDigitsCheckbox' )
+    );
 
     const infoDialog = new UnitsInformationDialog(
       model.isLab ? valuesPanelTandem.createTandem( 'infoDialog' ) : Tandem.OPT_OUT );
@@ -181,7 +190,7 @@ export default class MySolarSystemScreenView extends SolarSystemCommonScreenView
 
       // to keep infoButton right justified with valuesPanel when moreDataCheckbox is made invisible
       excludeInvisibleChildrenFromBounds: false,
-      children: [ moreDataCheckbox, infoButton ],
+      children: [ moreDataCheckbox, moreDigitsCheckbox, infoButton ],
 
       // Controls above valuesPanel are visible only when valuesPanel is visible, in Lab screen.
       visibleProperty: new DerivedProperty( [ this.valuesPanel.visibleProperty ],

--- a/js/common/view/MySolarSystemVisibleProperties.ts
+++ b/js/common/view/MySolarSystemVisibleProperties.ts
@@ -20,6 +20,9 @@ export default class MySolarSystemVisibleProperties extends SolarSystemCommonVis
   // Controls if the data panel shows all the numeric properties of the body
   public readonly moreDataVisibleProperty: BooleanProperty;
 
+  // Whether to include more digits in the numeric properties section
+  public readonly moreDigitsProperty: BooleanProperty;
+
   public constructor( isLab: boolean, tandem: Tandem ) {
     super( tandem );
 
@@ -30,6 +33,11 @@ export default class MySolarSystemVisibleProperties extends SolarSystemCommonVis
 
     this.moreDataVisibleProperty = new BooleanProperty( false, {
       tandem: isLab ? tandem.createTandem( 'moreDataVisibleProperty' ) : Tandem.OPT_OUT,
+      phetioFeatured: true
+    } );
+
+    this.moreDigitsProperty = new BooleanProperty( false, {
+      tandem: isLab ? tandem.createTandem( 'moreDigitsProperty' ) : Tandem.OPT_OUT,
       phetioFeatured: true
     } );
   }

--- a/js/common/view/ValuesColumnNode.ts
+++ b/js/common/view/ValuesColumnNode.ts
@@ -6,6 +6,7 @@
  * @author Agustín Vallejo (PhET Interactive Simulations)
  */
 
+import BooleanProperty from '../../../../axon/js/BooleanProperty.js';
 import DerivedProperty from '../../../../axon/js/DerivedProperty.js';
 import MappedProperty from '../../../../axon/js/MappedProperty.js';
 import Range from '../../../../dot/js/Range.js';
@@ -47,8 +48,7 @@ const POSITION_DECIMAL_PLACES = 2;
 const VELOCITY_DECIMAL_PLACES = 2;
 
 export default class ValuesColumnNode extends VBox {
-  public constructor( model: MySolarSystemModel, columnType: ValuesColumnTypes, keypadDialog: KeypadDialog, tandem: Tandem ) {
-
+  public constructor( model: MySolarSystemModel, moreDigitsProperty: BooleanProperty, columnType: ValuesColumnTypes, keypadDialog: KeypadDialog, tandem: Tandem ) {
     const titleStringProperty =
       columnType === ValuesColumnTypes.POSITION_X ? MySolarSystemStrings.dataPanel.XStringProperty :
       columnType === ValuesColumnTypes.POSITION_Y ? MySolarSystemStrings.dataPanel.YStringProperty :
@@ -61,17 +61,17 @@ export default class ValuesColumnNode extends VBox {
       combineOptions<RichTextOptions>( {}, SolarSystemCommonConstants.COLUMN_TITLE_OPTIONS, {
         maxWidth: 60
       } ) );
+    const titleTextBox = LABEL_ALIGN_GROUP.createBox( titleText );
 
-    // UI components for each Body, arranged in a column
-    const uiComponents = new VBox( {
-      children: model.bodies.map( body => ValuesColumnNode.createUIComponent( body, model, columnType, keypadDialog, tandem ) ),
+    const getUiComponents = ( moreDigits: boolean ) => new VBox( {
+      children: model.bodies.map( body => ValuesColumnNode.createUIComponent( body, model, columnType, moreDigits, keypadDialog, tandem ) ),
       spacing: 3.5,
       stretch: true
     } );
 
     super( {
       isDisposable: false,
-      children: [ LABEL_ALIGN_GROUP.createBox( titleText ), uiComponents ],
+      children: [ titleTextBox, getUiComponents( moreDigitsProperty.value ) ],
       stretch: true,
       tandem: tandem,
       phetioVisiblePropertyInstrumented: ( columnType === ValuesColumnTypes.MASS_NUMBER_CONTROL ),
@@ -79,18 +79,24 @@ export default class ValuesColumnNode extends VBox {
         phetioFeatured: true
       }
     } );
+
+    moreDigitsProperty.link( moreDigits => this.setChildren( [ titleTextBox, getUiComponents( moreDigits ) ] ) );
   }
 
   /**
    * Creates a UI component for editing some Property of Body.
    */
   private static createUIComponent( body: Body, model: MySolarSystemModel, columnType: ValuesColumnTypes,
+                                    moreDigits: boolean,
                                     keypadDialog: KeypadDialog, parentTandem: Tandem ): AlignBox {
 
     let uiComponent: Node;
 
     // Our minimum for the mass is larger than the body's minimum massProperty value
     const MASS_RANGE = new Range( 0.1, body.massProperty.range.max );
+
+    // extra digits to add because more digits is checked
+    const extraDigits = moreDigits ? 2 : 0;
 
     const clearPathsCallback = () => model.clearPaths();
 
@@ -160,7 +166,7 @@ export default class ValuesColumnNode extends VBox {
       uiComponent = new InteractiveNumberDisplay(
         positionXMappedProperty,
         POSITION_X_RANGE,
-        POSITION_DECIMAL_PLACES,
+        POSITION_DECIMAL_PLACES + extraDigits,
         SolarSystemCommonStrings.units.AUStringProperty,
         body.userIsControllingPositionProperty,
         body.colorProperty,
@@ -187,7 +193,7 @@ export default class ValuesColumnNode extends VBox {
       uiComponent = new InteractiveNumberDisplay(
         positionYMappedProperty,
         POSITION_Y_RANGE,
-        POSITION_DECIMAL_PLACES,
+        POSITION_DECIMAL_PLACES + extraDigits,
         SolarSystemCommonStrings.units.AUStringProperty,
         body.userIsControllingPositionProperty,
         body.colorProperty,
@@ -214,7 +220,7 @@ export default class ValuesColumnNode extends VBox {
       uiComponent = new InteractiveNumberDisplay(
         velocityXMappedProperty,
         VELOCITY_RANGE,
-        VELOCITY_DECIMAL_PLACES,
+        VELOCITY_DECIMAL_PLACES + extraDigits,
         SolarSystemCommonStrings.units.kmsStringProperty,
         body.userIsControllingVelocityProperty,
         body.colorProperty,
@@ -241,7 +247,7 @@ export default class ValuesColumnNode extends VBox {
       uiComponent = new InteractiveNumberDisplay(
         velocityYMappedProperty,
         VELOCITY_RANGE,
-        VELOCITY_DECIMAL_PLACES,
+        VELOCITY_DECIMAL_PLACES + extraDigits,
         SolarSystemCommonStrings.units.kmsStringProperty,
         body.userIsControllingVelocityProperty,
         body.colorProperty,

--- a/js/common/view/ValuesPanel.ts
+++ b/js/common/view/ValuesPanel.ts
@@ -39,7 +39,12 @@ const TITLE_MAX_WIDTH = 150;
 
 export default class ValuesPanel extends Panel {
 
-  public constructor( model: MySolarSystemModel, moreDataVisibleProperty: BooleanProperty, tandem: Tandem ) {
+  public constructor(
+    model: MySolarSystemModel,
+    moreDataVisibleProperty: BooleanProperty,
+    moreDigitsProperty: BooleanProperty,
+    tandem: Tandem
+  ) {
 
     const options = combineOptions<PanelOptions>( {}, SolarSystemCommonConstants.PANEL_OPTIONS, {
 
@@ -90,13 +95,13 @@ export default class ValuesPanel extends Panel {
     //----------------------------------------------------------------------------------------
     // Create columns of interactive UI components.
 
-    const iconsColumnNode = new ValuesColumnNode( model, ValuesColumnTypes.BODY_ICONS, keypadDialog, Tandem.OPT_OUT );
-    const massColumnNode = new ValuesColumnNode( model, ValuesColumnTypes.MASS, massesKeypadDialog, massSectionTandem.createTandem( 'massColumn' ) );
-    const massNumberControlColumnNode = new ValuesColumnNode( model, ValuesColumnTypes.MASS_NUMBER_CONTROL, keypadDialog, massSectionTandem.createTandem( 'massNumberControlColumn' ) );
-    const positionXColumnNode = new ValuesColumnNode( model, ValuesColumnTypes.POSITION_X, keypadDialog, positionSectionTandem.createTandem( 'xColumn' ) );
-    const positionYColumnNode = new ValuesColumnNode( model, ValuesColumnTypes.POSITION_Y, keypadDialog, positionSectionTandem.createTandem( 'yColumn' ) );
-    const velocityXColumnNode = new ValuesColumnNode( model, ValuesColumnTypes.VELOCITY_X, keypadDialog, velocitySectionTandem.createTandem( 'VxColumn' ) );
-    const velocityYColumnNode = new ValuesColumnNode( model, ValuesColumnTypes.VELOCITY_Y, keypadDialog, velocitySectionTandem.createTandem( 'VyColumn' ) );
+    const iconsColumnNode = new ValuesColumnNode( model, moreDigitsProperty, ValuesColumnTypes.BODY_ICONS, keypadDialog, Tandem.OPT_OUT );
+    const massColumnNode = new ValuesColumnNode( model, moreDigitsProperty, ValuesColumnTypes.MASS, massesKeypadDialog, massSectionTandem.createTandem( 'massColumn' ) );
+    const massNumberControlColumnNode = new ValuesColumnNode( model, moreDigitsProperty, ValuesColumnTypes.MASS_NUMBER_CONTROL, keypadDialog, massSectionTandem.createTandem( 'massNumberControlColumn' ) );
+    const positionXColumnNode = new ValuesColumnNode( model, moreDigitsProperty, ValuesColumnTypes.POSITION_X, keypadDialog, positionSectionTandem.createTandem( 'xColumn' ) );
+    const positionYColumnNode = new ValuesColumnNode( model, moreDigitsProperty, ValuesColumnTypes.POSITION_Y, keypadDialog, positionSectionTandem.createTandem( 'yColumn' ) );
+    const velocityXColumnNode = new ValuesColumnNode( model, moreDigitsProperty, ValuesColumnTypes.VELOCITY_X, keypadDialog, velocitySectionTandem.createTandem( 'VxColumn' ) );
+    const velocityYColumnNode = new ValuesColumnNode( model, moreDigitsProperty, ValuesColumnTypes.VELOCITY_Y, keypadDialog, velocitySectionTandem.createTandem( 'VyColumn' ) );
 
     // Put a wrapper around massNumberControlColumnNode, so that PhET-iO clients have independent control over the visibility
     // of sliders. Use a VBox so that we have dynamic layout.

--- a/my-solar-system-strings_en.json
+++ b/my-solar-system-strings_en.json
@@ -47,6 +47,9 @@
   "dataPanel.moreData": {
     "value": "More Data"
   },
+  "dataPanel.moreDecimalDigits": {
+    "value": "Show More Digits"
+  },
   "mode.sunAndPlanet": {
     "value": "Sun, Planet"
   },
@@ -128,6 +131,9 @@
   "a11y": {
     "moreData": {
       "value": "More Data"
+    },
+    "moreDecimalDigits": {
+      "value": "More Decimal Digits"
     },
     "info": {
       "value": "Info"


### PR DESCRIPTION
It's a toggle that shows up when you click the "more data" toggle, and allows for a little bit more precision when recording data(especially since values are measured in AU and km/s, which are pretty large units relatively).